### PR TITLE
Move callback to after png renders

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,12 @@ module.exports = function (dest, d3n, callback) {
     console.log(`>> Exported "${dest}.svg"`);
   });
 
-  if (typeof callback === 'function') { // used for testing
-    callback(d3n);
-  }
-
   var svgBuffer = new Buffer(svgString, 'utf-8');
   svg2png(svgBuffer)
     .then(buffer => fs.writeFile(`${dest}.png`, buffer))
-    .then(() => console.log(`>> Exported: "${dest}.png"`))
+    .then(() => {
+      console.log(`>> Exported: "${dest}.png"`);
+      if (typeof callback === 'function') callback();
+    })
     .catch(e => console.error('ERR:', e));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -11,11 +11,11 @@ const chart = pieChart(data);
 // test camelCase in svgString
 chart.d3Element.select('svg').append('radialGradient').attr('offset', '0%');
 
-output('dist/test', chart, (d3n) => {
+output('dist/test', chart, () => {
   // assertion test
   try {
     const expectedSvg = fs.readFileSync('test/expected.svg', 'utf-8');
-    assert.equal(d3n.svgString(), expectedSvg);
+    assert.equal(chart.svgString(), expectedSvg);
   } catch (ex) {
     console.log(ex);
   }


### PR DESCRIPTION
Moved the callback to after the png finishes. That way, you can do things like upload, crop etc..