### PR TITLE
Update Readme. Add option for PNG sizing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ npm install d3node-output
 const output = require('d3node-output')
 const voronoi = require('d3node-voronoi');
 const data = new Array(99);
+//crop your png to a custom size
+const pngOpts = {width: 100, height: 200};
 
 // output files to /dist dir
-output('./dist/myVoronoi', voronoi(data));
+output('./dist/myVoronoi', voronoi(data), pngOpts, callback);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ npm install d3node-output
 const output = require('d3node-output')
 const voronoi = require('d3node-voronoi');
 const data = new Array(99);
-//crop your png to a custom size
-//defaults to the size of your svg if not defined
-const pngOpts = {width: 100, height: 200};
+
+// crop your png to a custom size
+// defaults to the size of your svg if not defined
+const options = {width: 100, height: 200};
 
 // output files to /dist dir
-output('./dist/myVoronoi', voronoi(data), pngOpts, callback);
+output('./dist/myVoronoi', voronoi(data), options, callback);
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ const output = require('d3node-output')
 const voronoi = require('d3node-voronoi');
 const data = new Array(99);
 //crop your png to a custom size
+//defaults to the size of your svg if not defined
 const pngOpts = {width: 100, height: 200};
 
 // output files to /dist dir

--- a/index.js
+++ b/index.js
@@ -23,13 +23,12 @@ module.exports = function (dest, d3n, callback) {
     console.log(`>> Exported "${dest}.svg"`);
   });
 
-  if (typeof callback === 'function') { // used for testing
-    callback(d3n);
-  }
-
   var svgBuffer = new Buffer(svgString, 'utf-8');
   svg2png(svgBuffer)
     .then(buffer => fs.writeFile(`${dest}.png`, buffer))
-    .then(() => console.log(`>> Exported: "${dest}.png"`))
+    .then(() => {
+      console.log(`>> Exported: "${dest}.png"`);
+      if (typeof callback === 'function') callback();
+    })
     .catch(e => console.error('ERR:', e));
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const svg2png = require('svg2png');
 
-module.exports = function (dest, d3n, callback) {
+module.exports = function (dest, d3n, opts, callback) {
   const d3 = d3n.d3;
 
   function eachGeoQuantize (d) {
@@ -24,7 +24,7 @@ module.exports = function (dest, d3n, callback) {
   });
 
   var svgBuffer = new Buffer(svgString, 'utf-8');
-  svg2png(svgBuffer, {})
+  svg2png(svgBuffer, opts || {})
     .then(buffer => fs.writeFileSync(`${dest}.png`, buffer))
     .then(() => {
       console.log(`>> Exported: "${dest}.png"`);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (dest, d3n, callback) {
   });
 
   var svgBuffer = new Buffer(svgString, 'utf-8');
-  svg2png(svgBuffer)
+  svg2png(svgBuffer, {})
     .then(buffer => fs.writeFileSync(`${dest}.png`, buffer))
     .then(() => {
       console.log(`>> Exported: "${dest}.png"`);

--- a/test/index.js
+++ b/test/index.js
@@ -11,11 +11,11 @@ const chart = pieChart(data);
 // test camelCase in svgString
 chart.d3Element.select('svg').append('radialGradient').attr('offset', '0%');
 
-output('dist/test', chart, (d3n) => {
+output('dist/test', chart, () => {
   // assertion test
   try {
     const expectedSvg = fs.readFileSync('test/expected.svg', 'utf-8');
-    assert.equal(d3n.svgString(), expectedSvg);
+    assert.equal(chart.svgString(), expectedSvg);
   } catch (ex) {
     console.log(ex);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ const csvString = fs.readFileSync('test/data.csv').toString();
 var data = d3.csvParse(csvString);
 
 const chart = pieChart(data);
+const opts = {width: 100, height: 100};
 
 // test camelCase in svgString
 chart.d3Element.select('svg').append('radialGradient').attr('offset', '0%');

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ const chart = pieChart(data);
 // test camelCase in svgString
 chart.d3Element.select('svg').append('radialGradient').attr('offset', '0%');
 
-output('dist/test', chart, () => {
+output('dist/test', chart, opts, () => {
   // assertion test
   try {
     const expectedSvg = fs.readFileSync('test/expected.svg', 'utf-8');


### PR DESCRIPTION
svg2png [has an option](https://github.com/domenic/svg2png) to set a custom width/height output (it is the only option for customization)

This allows you to pass in your png output specs.

Use case is:
`output('./dist/myVoronoi', voronoi(data), pngOpts, callback);`

This preserves the full functionality of svg2png

